### PR TITLE
Finished registration and checkin commands

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,8 @@
     },
     "env": {
         "node": true,
-        "es6": true
+        "es6": true,
+        "mocha": true
     },
     "extends": "eslint:recommended"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.tern-project
 config.json
 database.sqlite3
 

--- a/commands/event/checkIn.js
+++ b/commands/event/checkIn.js
@@ -36,15 +36,13 @@ module.exports = class CheckInCommand extends Command {
             event = await Event.findCurrentEvent();
         }
 
-        if (!event) {
+        if (!event || !event.visible) {
             return msg.say(`Sorry, but I could not find the event.`);
         }
 
         if (event.status.checkIn === Event.STATUS.CLOSED) {
             return msg.say('Sorry, but the check-in is closed.');
         }
-
-        // TODO: shouldn't we check if event is visible as well?
 
         if (!await event.playerIsRegistered(msg.author.id)) {
             return msg.say(oneLine`

--- a/commands/event/checkIn.js
+++ b/commands/event/checkIn.js
@@ -53,6 +53,7 @@ module.exports = class CheckInCommand extends Command {
 
         // TODO: Handle duplicate check-ins?
         player = await Player.findByDiscordId(msg.author.id);
+        player.updateMaxMMR();
         await event.checkIn(player);
 
         return msg.say(`Checked you in to ${event.name}.`);

--- a/commands/event/checkIn.js
+++ b/commands/event/checkIn.js
@@ -53,7 +53,7 @@ module.exports = class CheckInCommand extends Command {
 
         // TODO: Handle duplicate check-ins?
         player = await Player.findByDiscordId(msg.author.id);
-        player.updateMaxMMR();
+        await player.updateMaxMMR();
         await event.checkIn(player);
 
         return msg.say(`${msg.author}, checked you in to ${event.name}.`);

--- a/commands/event/checkIn.js
+++ b/commands/event/checkIn.js
@@ -56,6 +56,6 @@ module.exports = class CheckInCommand extends Command {
         player.updateMaxMMR();
         await event.checkIn(player);
 
-        return msg.say(`Checked you in to ${event.name}.`);
+        return msg.say(`${msg.author}, checked you in to ${event.name}.`);
     }
 };

--- a/commands/event/checkIn.js
+++ b/commands/event/checkIn.js
@@ -1,6 +1,6 @@
 const { Command } = require('discord.js-commando');
 const oneLine = require('common-tags').oneLine;
-
+const Player = require('../../lib/player');
 const Event = require('../../lib/event');
 
 module.exports = class CheckInCommand extends Command {
@@ -28,7 +28,7 @@ module.exports = class CheckInCommand extends Command {
     }
 
     async run(msg, { name }) {
-        let event;
+        let event, player;
 
         if (name !== '') {
             event = await Event.findByName(name);
@@ -44,7 +44,18 @@ module.exports = class CheckInCommand extends Command {
             return msg.say('Sorry, but the check-in is closed.');
         }
 
-        // todo: check-in player to the event
+        // TODO: shouldn't we check if event is visible as well?
+
+        if (!await event.playerIsRegistered(msg.author.id)) {
+            return msg.say(oneLine`
+                You aren't registered to this event.
+                Use \`event-register ${event.name}\` to register.
+            `);
+        }
+
+        // TODO: Handle duplicate check-ins?
+        player = await Player.findByDiscordId(msg.author.id);
+        await event.checkIn(player);
 
         return msg.say(`Checked you in to ${event.name}.`);
     }

--- a/commands/event/checkInList.js
+++ b/commands/event/checkInList.js
@@ -1,6 +1,5 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
-
+const { TournamentListEmbed } = require('../../lib/player-list-embed.js');
 const Event = require('../../lib/event');
 
 module.exports = class CheckInListCommand extends Command {
@@ -40,7 +39,17 @@ module.exports = class CheckInListCommand extends Command {
             return msg.say(`Sorry, but I could not find the event.`);
         }
 
-        // todo: replace with formatted checked-in player list
-        return msg.say(`Yes.`);
+        const players = await event.getCheckedInPlayers();
+
+        if (!players.length) {
+            return msg.say('There are no players checked in for this tournament.');
+        }
+
+        const embed = new TournamentListEmbed(
+            `Checked in players for "${event.name}"`,
+            players
+        );
+
+        return msg.channel.send({embed: embed.getEmbed()});
     }
 };

--- a/commands/event/closeCheckin.js
+++ b/commands/event/closeCheckin.js
@@ -1,5 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
 
 const Event = require('../../lib/event');
 

--- a/commands/event/closeRegistration.js
+++ b/commands/event/closeRegistration.js
@@ -1,5 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
 
 const Event = require('../../lib/event');
 

--- a/commands/event/create.js
+++ b/commands/event/create.js
@@ -1,5 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
 
 const Event = require('../../lib/event');
 

--- a/commands/event/hide.js
+++ b/commands/event/hide.js
@@ -1,5 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
 
 const Event = require('../../lib/event');
 

--- a/commands/event/link.js
+++ b/commands/event/link.js
@@ -19,7 +19,6 @@ module.exports = class LinkCommand extends Command {
                         What's your steamid64?
                         If you're not sure, you can get it with https://www.steamidfinder.com/`,
                     type: 'string',
-                    default: '',
                     validate: text => {
                         return !isNaN(text);
                     }

--- a/commands/event/link.js
+++ b/commands/event/link.js
@@ -63,7 +63,7 @@ module.exports = class LinkCommand extends Command {
                 maxmmr: rllvPlayer.maxmmr
             });
         } else {
-            player = Player.create({
+            player = await Player.create({
                 discordid,
                 discordnick,
                 steamid64,

--- a/commands/event/link.js
+++ b/commands/event/link.js
@@ -38,6 +38,10 @@ module.exports = class LinkCommand extends Command {
             return msg.say('Your account is already linked. Use `unlink-steam` to unlink it.');
         }
 
+        if (await Player.steamId64Taken(steamid64)) {
+            return msg.say('Someone is already using this steamid64.');
+        }
+
         // Steamid provided - check if user is in the rocketleague.lv database
         // before touching our own.
         try {

--- a/commands/event/link.js
+++ b/commands/event/link.js
@@ -45,9 +45,8 @@ module.exports = class LinkCommand extends Command {
             rllvPlayer = await rllv.RocketLeagueAPI.getPlayer(steamid64);
         } catch (e) {
             if (e instanceof rllv.PlayerNotFoundException) {
-                player.unsetSteamId64();
                 return msg.say(oneLine`
-                    Your steamid wasn\'t found in the http://rocketleague.lv/ database. 
+                    Your steamid wasn\'t found in the http://rocketleague.lv/ database.
                     Ask an administrator to be added first.
                 `);
             }

--- a/commands/event/link.js
+++ b/commands/event/link.js
@@ -30,10 +30,14 @@ module.exports = class LinkCommand extends Command {
     async run(msg, { steamid64 }) {
         let discordid = msg.author.id;
         let player = await Player.findByDiscordId(discordid);
-        let discordnick = msg.member.nickname || msg.author.username
+        let discordnick = msg.member.nickname || msg.author.username;
 
-        if (player) {
+        if (player && player.steamid64) {
+            // Player exists and has a steamid linked
             return msg.say('Your account is already linked. Use `unlink-steam` to unlink it.');
+        } else if (player) {
+            // Player exists, but doesn't have a steamid linked
+            player.setSteamId64(steamid64);
         }
 
         player = Player.create({

--- a/commands/event/list.js
+++ b/commands/event/list.js
@@ -1,7 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
-
-const Event = require('../../lib/event');
 
 module.exports = class ListCommand extends Command {
     constructor(client) {
@@ -20,8 +17,6 @@ module.exports = class ListCommand extends Command {
     }
 
     async run(msg) {
-        const events = await Event.findVisible();
-
         // todo: replace with formatted event list
         return msg.say(`Sorry, I can't remember any events.`);
     }

--- a/commands/event/list.js
+++ b/commands/event/list.js
@@ -1,4 +1,6 @@
+const Discord = require('discord.js');
 const { Command } = require('discord.js-commando');
+const Event = require('../../lib/event');
 
 module.exports = class ListCommand extends Command {
     constructor(client) {
@@ -17,7 +19,28 @@ module.exports = class ListCommand extends Command {
     }
 
     async run(msg) {
-        // todo: replace with formatted event list
-        return msg.say(`Sorry, I can't remember any events.`);
+        const events = await Event.findVisible();
+
+        if (!events.length) return msg.say('Sorry, there are no upcoming events.'); 
+
+        const embed = new Discord.RichEmbed();
+        embed.setTitle('Upcoming events');
+        embed.setColor(0x4549cc);
+
+        let eventNames = [];
+        let eventStatusesRegistration = [];
+        let eventStatusesCheckIn = [];
+
+        events.forEach(ev => {
+            eventNames.push(ev.name);
+            eventStatusesRegistration.push(ev.status.registration);
+            eventStatusesCheckIn.push(ev.status.checkIn);
+        });
+
+        embed.addField('Name', eventNames.join('\n'), true);
+        embed.addField('Registration', eventStatusesRegistration.join('\n'), true);
+        embed.addField('Check in', eventStatusesCheckIn.join('\n'), true);
+
+        return msg.channel.send({embed: embed});
     }
 };

--- a/commands/event/openCheckIn.js
+++ b/commands/event/openCheckIn.js
@@ -1,5 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
 
 const Event = require('../../lib/event');
 

--- a/commands/event/openRegistration.js
+++ b/commands/event/openRegistration.js
@@ -1,5 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
 
 const Event = require('../../lib/event');
 

--- a/commands/event/openRegistration.js
+++ b/commands/event/openRegistration.js
@@ -16,7 +16,6 @@ module.exports = class OpenRegistrationCommand extends Command {
                     key: 'name',
                     prompt: 'What event do you want to open the registration to?',
                     type: 'string',
-                    default: ''
                 }
             ]
         });
@@ -30,11 +29,7 @@ module.exports = class OpenRegistrationCommand extends Command {
     async run(msg, { name }) {
         let event;
 
-        if (name !== '') {
-            event = await Event.findByName(name);
-        } else {
-            event = await Event.findCurrentEvent();
-        }
+        event = await Event.findByName(name);
 
         if (!event) {
             return msg.say(`Sorry, but I could not find the event.`);

--- a/commands/event/register.js
+++ b/commands/event/register.js
@@ -58,7 +58,7 @@ module.exports = class RegisterCommand extends Command {
             return msg.say('You are already registered to this event.');
         }
 
-        player.getMaxMMR();
+        player.updateMaxMMR();
         await event.register(player);
 
         return msg.say(`Registered you to ${event.name}.`);

--- a/commands/event/register.js
+++ b/commands/event/register.js
@@ -36,7 +36,7 @@ module.exports = class RegisterCommand extends Command {
             event = await Event.findCurrentEvent();
         }
 
-        if (!event) {
+        if (!event || !event.visible) {
             return msg.say(`Sorry, but I could not find the event.`);
         }
 
@@ -44,7 +44,6 @@ module.exports = class RegisterCommand extends Command {
             return msg.say('Sorry, but the registration is closed.');
         }
 
-        // TODO: shouldn't we check if event is visible as well?
         player = await Player.findByDiscordId(msg.author.id);
 
         if (!player || !player.steamid64) {

--- a/commands/event/register.js
+++ b/commands/event/register.js
@@ -60,6 +60,6 @@ module.exports = class RegisterCommand extends Command {
         player.updateMaxMMR();
         await event.register(player);
 
-        return msg.say(`Registered you to ${event.name}.`);
+        return msg.say(`${msg.author}, registered you to ${event.name}.`);
     }
 };

--- a/commands/event/register.js
+++ b/commands/event/register.js
@@ -59,7 +59,7 @@ module.exports = class RegisterCommand extends Command {
         }
 
         player.getMaxMMR();
-        event.register(player);
+        await event.register(player);
 
         return msg.say(`Registered you to ${event.name}.`);
     }

--- a/commands/event/register.js
+++ b/commands/event/register.js
@@ -57,7 +57,7 @@ module.exports = class RegisterCommand extends Command {
             return msg.say('You are already registered to this event.');
         }
 
-        player.updateMaxMMR();
+        await player.updateMaxMMR();
         await event.register(player);
 
         return msg.say(`${msg.author}, registered you to ${event.name}.`);

--- a/commands/event/registrationList.js
+++ b/commands/event/registrationList.js
@@ -1,5 +1,5 @@
 const { Command } = require('discord.js-commando');
-const Discord = require('discord.js');
+const { TournamentListEmbed } = require('../../lib/player-list-embed.js');
 const Event = require('../../lib/event');
 
 module.exports = class RegistrationListCommand extends Command {
@@ -40,25 +40,17 @@ module.exports = class RegistrationListCommand extends Command {
             return msg.say(`Sorry, but I could not find the event.`);
         }
 
-        const embed = new Discord.RichEmbed()
-            .setTitle(`Registered players for "${event.name}"`)
-            .setColor(0x228B22);
         const players = await event.getRegisteredPlayers();
-        let playerNames = [];
-        let playerMMR = [];
 
         if (!players.length) {
             return msg.say('There are no players registered for this tournament.');
         }
 
-        players.forEach(player => {
-            playerNames.push(player.discordnick);
-            playerMMR.push(player.maxmmr);
-        });
+        const embed = new TournamentListEmbed(
+            `Registered players for "${event.name}"`,
+            players
+        );
 
-        embed.addField('Nickname', playerNames.join('\n'), true);
-        embed.addField('MMR', playerMMR.join('\n'), true);
-
-        return msg.channel.send({embed});
+        return msg.channel.send({embed: embed.getEmbed()});
     }
 };

--- a/commands/event/registrationList.js
+++ b/commands/event/registrationList.js
@@ -1,6 +1,5 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
-
+const Discord = require('discord.js');
 const Event = require('../../lib/event');
 
 module.exports = class RegistrationListCommand extends Command {
@@ -28,6 +27,7 @@ module.exports = class RegistrationListCommand extends Command {
     }
 
     async run(msg, { name }) {
+
         let event;
 
         if (name !== '') {
@@ -36,11 +36,29 @@ module.exports = class RegistrationListCommand extends Command {
             event = await Event.findCurrentEvent();
         }
 
-        if (!event) {
+        if (!event || !event.visible) {
             return msg.say(`Sorry, but I could not find the event.`);
         }
 
-        // todo: replace with formatted registered player list
-        return msg.say(`Yes.`);
+        const embed = new Discord.RichEmbed()
+            .setTitle(`Registered players for "${event.name}"`)
+            .setColor(0x228B22);
+        const players = await event.getRegisteredPlayers();
+        let playerNames = [];
+        let playerMMR = [];
+
+        if (!players.length) {
+            return msg.say('There are no players registered for this tournament.');
+        }
+
+        players.forEach(player => {
+            playerNames.push(player.discordnick);
+            playerMMR.push(player.maxmmr);
+        });
+
+        embed.addField('Nickname', playerNames.join('\n'), true);
+        embed.addField('MMR', playerMMR.join('\n'), true);
+
+        return msg.channel.send({embed});
     }
 };

--- a/commands/event/registrationList.js
+++ b/commands/event/registrationList.js
@@ -43,7 +43,7 @@ module.exports = class RegistrationListCommand extends Command {
         const players = await event.getRegisteredPlayers();
 
         if (!players.length) {
-            return msg.say('There are no players registered for this tournament.');
+            return msg.say('There are no players registered for this event.');
         }
 
         const embed = new TournamentListEmbed(

--- a/commands/event/show.js
+++ b/commands/event/show.js
@@ -1,6 +1,4 @@
 const { Command } = require('discord.js-commando');
-const oneLine = require('common-tags').oneLine;
-
 const Event = require('../../lib/event');
 
 module.exports = class ShowCommand extends Command {
@@ -16,8 +14,7 @@ module.exports = class ShowCommand extends Command {
                 {
                     key: 'name',
                     prompt: 'What event do you want to show?',
-                    type: 'string',
-                    default: ''
+                    type: 'string'
                 }
             ]
         });

--- a/commands/event/unlink.js
+++ b/commands/event/unlink.js
@@ -19,7 +19,11 @@ module.exports = class UnlinkCommand extends Command {
             return msg.say('Your account isn\'t linked. Use `link-steam` to link it!');
         }
 
-        await player.delete();
+        if (!player.steamid64) {
+            return msg.say('Your account isn\'t linked. Use `link-steam` to link it!');
+        }
+
+        await player.unsetSteamId64();
 
         return msg.say('Account successfully unlinked!');
     }

--- a/lib/event.js
+++ b/lib/event.js
@@ -104,12 +104,19 @@ class Event {
     }
 
     async register(player) {
-        player.checkedIn = false;
 
-        this.players.push(player);
-        
+        const p = {
+            discordid: player.discordid,
+            discordnick: player.discordnick,
+            steamid64: player.steamid64,
+            maxmmr: player.maxmmr,
+            checkedIn: false
+        };
+
+        this.players.push(p);
+
         await mongodb.collection('events').updateOne({_id: this._id}, {$push: {
-            players: player
+            players: p
         }});
 
         return true;
@@ -132,10 +139,11 @@ class Event {
 
     async playerIsRegistered(discordid) {
         if (isNaN(discordid)) return null;
-        return await mongodb.collection('events').findOne({
+
+        return Boolean(await mongodb.collection('events').findOne({
             _id: this._id,
             'players.discordid': discordid
-        });
+        }));
     }
 }
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -126,7 +126,7 @@ class Event {
         await mongodb.collection('events').updateOne({
             '_id': this._id,
             'players.discordid': player.discordid
-        }, {$set: {'players.$.checkedIn': true}});
+        }, {$set: {'players.$.checkedIn': true, 'players.$.maxmmr': player.maxmmr}});
     }
 
     async getRegisteredPlayers() {

--- a/lib/event.js
+++ b/lib/event.js
@@ -42,7 +42,7 @@ class Event {
             return null;
         }
 
-        return events[0];
+        return new Event(events[0]);
     }
 
     static findVisible() {
@@ -143,7 +143,17 @@ class Event {
     }
 
     async getCheckedInPlayers() {
+        const results = await mongodb.collection('events').aggregate([
+            {$match: {'_id': this._id }},
+            {$unwind: '$players'},
+            {$match: {'players.checkedIn': true }},
+            {$project: {'players': 1, '_id': 0}},
+            {$sort: {'players.maxmmr': -1}}
+        ]).toArray();
 
+        return results.map(player => {
+            return player.players;
+        });
     }
 
     async playerIsRegistered(discordid) {

--- a/lib/event.js
+++ b/lib/event.js
@@ -104,18 +104,22 @@ class Event {
     }
 
     async register(player) {
+        player.checkedIn = false;
 
         this.players.push(player);
+        
         await mongodb.collection('events').updateOne({_id: this._id}, {$push: {
             players: player
         }});
 
         return true;
-
     }
 
     async checkIn(player) {
-
+        await mongodb.collection('events').updateOne({
+            '_id': this._id,
+            'players.discordid': player.discordid
+        }, {$set: {'players.$.checkedIn': true}});
     }
 
     async getRegisteredPlayers() {
@@ -124,6 +128,14 @@ class Event {
 
     async getCheckedInPlayers() {
 
+    }
+
+    async playerIsRegistered(discordid) {
+        if (isNaN(discordid)) return null;
+        return await mongodb.collection('events').findOne({
+            _id: this._id,
+            'players.discordid': discordid
+        });
     }
 }
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -36,17 +36,18 @@ class Event {
                 {'status.registration': STATUS.OPEN},
                 {'status.checkIn': STATUS.OPEN}
             ]
-        }).toArray();
+        }).sort({ _id: -1 }).toArray();
 
-        if (events.length !== 1) {
+        if (!events.length) {
             return null;
         }
 
         return new Event(events[0]);
     }
 
-    static findVisible() {
-        return mongodb.collection('events').find({visible: true}).map(data => new Event(data));
+    static async findVisible() {
+        const events = await mongodb.collection('events').find({visible: true}).sort({ _id: -1 }).toArray();
+        return events.map(data => new Event(data));
     }
 
     constructor({_id, name, players = [], visible = false, status = {registration: STATUS.CLOSED, checkIn: STATUS.CLOSED}}) {

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,4 +1,5 @@
 const mongodb = require('./mongodb');
+const Player = require('./player');
 
 const STATUS = {
     OPEN: 'open',
@@ -95,7 +96,10 @@ class Event {
     }
 
     async hasRegistered(player) {
-        let registeredPlayer = await mongodb.collection('events').findOne({'players._id': player._id});
+        let registeredPlayer = await mongodb.collection('events').findOne({
+            '_id': this._id,
+            'players.discordid': player.discordid
+        });
 
         if (registeredPlayer) {
             return true;
@@ -120,7 +124,6 @@ class Event {
             players: p
         }});
 
-        return true;
     }
 
     async checkIn(player) {
@@ -139,7 +142,7 @@ class Event {
         ]).toArray();
 
         return results.map(player => {
-            return player.players;
+            return new Player(player.players);
         });
     }
 
@@ -153,7 +156,7 @@ class Event {
         ]).toArray();
 
         return results.map(player => {
-            return player.players;
+            return new Player(player.players);
         });
     }
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -93,7 +93,24 @@ class Event {
         await mongodb.collection('events').updateOne({_id: this._id}, {$set: {visible: false}});
     }
 
+    async hasRegistered(player) {
+        let registeredPlayer = await mongodb.collection('events').findOne({'players._id': player._id});
+
+        if (registeredPlayer) {
+            return true;
+        }
+
+        return false;
+    }
+
     async register(player) {
+
+        this.players.push(player);
+        await mongodb.collection('events').updateOne({_id: this._id}, {$push: {
+            players: player
+        }});
+
+        return true;
 
     }
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -130,7 +130,16 @@ class Event {
     }
 
     async getRegisteredPlayers() {
+        const results = await mongodb.collection('events').aggregate([
+            {$match: {'_id': this._id }},
+            {$unwind: '$players'},
+            {$project: {'players': 1, '_id': 0}},
+            {$sort: {'players.maxmmr': -1}}
+        ]).toArray();
 
+        return results.map(player => {
+            return player.players;
+        });
     }
 
     async getCheckedInPlayers() {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -11,5 +11,5 @@ module.exports = {
 
 MongoClient.connect(config.mongodb).then(function (client) {
     pino.info('MongoDB connected');
-    module.exports.client = client
+    module.exports.client = client;
 });

--- a/lib/player-list-embed.js
+++ b/lib/player-list-embed.js
@@ -1,0 +1,29 @@
+const Discord = require('discord.js');
+
+class TournamentListEmbed {
+    constructor(title, players, color) {
+        this.title = title || 'Player list';
+        this.color = color || 0x228B22;
+        this.players = players;
+        this.embed = new Discord.RichEmbed()
+            .setTitle(this.title)
+            .setColor(this.color);
+    }
+
+    getEmbed() {
+        let playerNames = [];
+        let playerMMR = [];
+
+        this.players.forEach(player => {
+            playerNames.push(player.discordnick);
+            playerMMR.push(player.maxmmr);
+        });
+
+        this.embed.addField('Nickname', playerNames.join('\n'), true);
+        this.embed.addField('MMR', playerMMR.join('\n'), true);
+
+        return this.embed;
+    }
+}
+
+module.exports = {TournamentListEmbed};

--- a/lib/player.js
+++ b/lib/player.js
@@ -38,10 +38,12 @@ class Player {
             if (e instanceof rllv.PlayerNotFoundException) return;
             throw e;
         }
+        
+        const maxmmr = parseInt(response.maxmmr, 10); 
 
-        this.maxmmr = response.maxmmr;
+        this.maxmmr = maxmmr;
         await mongodb.collection('players').updateOne({_id: this._id}, {$set: {
-            'maxmmr': this.maxmmr
+            'maxmmr': maxmmr
         }});
     }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -45,6 +45,24 @@ class Player {
         }});
     }
 
+    async unsetSteamId64() {
+        this.steamid64 = '';
+        await mongodb.collection('players').updateOne({_id: this._id}, {$set: {
+            steamid64: ''
+        }});
+    }
+
+    async setSteamId64(steamid64) {
+        if (isNaN(steamid64)) {
+            return;
+        }
+
+        await mongodb.collection('players').updateOne({_id: this._id}, {$set: {
+            steamid64: steamid64
+        }});
+
+    }
+
     async delete() {
         await mongodb.collection('players').findOneAndDelete({_id: this._id});
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -29,7 +29,7 @@ class Player {
 
     static async steamId64Taken(steamid64) {
         if (!steamid64) return false;
-        return Boolean(mongodb.collection('players').count({steamid64}));
+        return Boolean(await mongodb.collection('players').count({steamid64}));
     }
 
     async updateMaxMMR() {

--- a/lib/player.js
+++ b/lib/player.js
@@ -2,12 +2,13 @@ const mongodb = require('./mongodb');
 const rllv = require('./rllv-api');
 
 class Player {
-    constructor({_id, discordid, discordnick, steamid64, maxmmr}) {
+    constructor({_id, discordid, discordnick, steamid64, maxmmr, checkedIn}) {
         this._id = _id;
         this.discordid = discordid;
         this.discordnick = discordnick;
         this.steamid64 = steamid64;
         this.maxmmr = maxmmr;
+        this.checkedIn = checkedIn || false;
     }
 
     static async create({discordid, discordnick, steamid64, maxmmr}) {
@@ -27,7 +28,7 @@ class Player {
         return new Player(data);
     }
 
-    async getMaxMMR() {
+    async updateMaxMMR() {
         let response;
 
         if (!this.steamid64) return;
@@ -46,8 +47,8 @@ class Player {
     }
 
     async unsetSteamId64() {
-        this.steamid64 = '';
-        await mongodb.collection('players').updateOne({_id: this._id}, {$set: {
+        delete this.steamid64;
+        await mongodb.collection('players').updateOne({_id: this._id}, {$unset: {
             steamid64: ''
         }});
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -63,6 +63,10 @@ class Player {
         // TODO: May be check if "params" contains any of the necessary keys, like steamid64, maxmmr, etc.
         if (typeof params !== 'object') return;
 
+        Object.keys(params).forEach(key => {
+            this[key] = params[key];
+        });
+
         await mongodb.collection('players').updateOne({_id: this._id}, {$set: params});
 
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -27,6 +27,11 @@ class Player {
         return new Player(data);
     }
 
+    static async steamId64Taken(steamid64) {
+        if (!steamid64) return false;
+        return Boolean(mongodb.collection('players').count({steamid64}));
+    }
+
     async updateMaxMMR() {
         let response;
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -10,9 +10,9 @@ class Player {
         this.maxmmr = maxmmr;
     }
 
-    static async create({discordid, discordnick, steamid64}) {
+    static async create({discordid, discordnick, steamid64, maxmmr}) {
 
-        const player = new Player({discordid, discordnick, steamid64});
+        const player = new Player({discordid, discordnick, steamid64, maxmmr});
 
         await mongodb.collection('players').insert(player);
 
@@ -52,14 +52,11 @@ class Player {
         }});
     }
 
-    async setSteamId64(steamid64) {
-        if (isNaN(steamid64)) {
-            return;
-        }
+    async setParams(params) {
+        // TODO: May be check if "params" contains any of the necessary keys, like steamid64, maxmmr, etc.
+        if (typeof params !== 'object') return;
 
-        await mongodb.collection('players').updateOne({_id: this._id}, {$set: {
-            steamid64: steamid64
-        }});
+        await mongodb.collection('players').updateOne({_id: this._id}, {$set: params});
 
     }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -2,13 +2,12 @@ const mongodb = require('./mongodb');
 const rllv = require('./rllv-api');
 
 class Player {
-    constructor({_id, discordid, discordnick, steamid64, maxmmr, checkedIn}) {
+    constructor({_id, discordid, discordnick, steamid64, maxmmr}) {
         this._id = _id;
         this.discordid = discordid;
         this.discordnick = discordnick;
         this.steamid64 = steamid64;
         this.maxmmr = maxmmr;
-        this.checkedIn = checkedIn || false;
     }
 
     static async create({discordid, discordnick, steamid64, maxmmr}) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -30,12 +30,12 @@ class Player {
     async getMaxMMR() {
         let response;
 
-        if (!this.steamid64) return null;
+        if (!this.steamid64) return;
 
         try {
             response = await rllv.RocketLeagueAPI.getPlayer(this.steamid64);
         } catch (e) {
-            if (e instanceof rllv.PlayerNotFoundException) return null;
+            if (e instanceof rllv.PlayerNotFoundException) return;
             throw e;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -26,6 +32,134 @@
         "is-buffer": "1.1.6"
       }
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -34,6 +168,76 @@
         "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
       }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
     },
     "bson": {
       "version": "1.0.4",
@@ -68,6 +272,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
     "common-tags": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
@@ -75,6 +285,18 @@
       "requires": {
         "babel-runtime": "6.26.0"
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "dev": true
     },
     "core-js": {
       "version": "2.5.1",
@@ -93,6 +315,21 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "discord.js": {
       "version": "11.2.1",
@@ -134,6 +371,12 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
     "fast-json-parse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
@@ -157,30 +400,210 @@
         "debug": "2.6.9"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "mongodb": {
       "version": "2.2.33",
@@ -227,6 +650,12 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -234,6 +663,24 @@
       "requires": {
         "wrappy": "1.0.2"
       }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "pino": {
       "version": "4.8.0",
@@ -253,6 +700,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.1.tgz",
       "integrity": "sha1-o0JcnKvVDRxsAuVDlBoRiVZnvRA="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -295,6 +748,15 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
       "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
     "require-all": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/require-all/-/require-all-2.2.0.tgz",
@@ -314,6 +776,16 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
+    "rewire": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-3.0.1.tgz",
+      "integrity": "sha512-6bC/xDkpz83lOUYYH7y0AyYgfW/JVfLFN/M1vydZxPmPans/Wx/Sg8V1by6SsSwBB1+gO7ScxLBe8w4tZhux+Q==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -324,10 +796,31 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
     "snekfetch": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.5.3.tgz",
       "integrity": "sha512-lAlDofxstlGiDgxW5IGSgvOwA3P49kvvfrMyrEdXgtnx6IX/jMsoShCVFoRHY6zd34BvOLDNjYGfrpgsrfCgDQ=="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
     },
     "split2": {
       "version": "2.2.0",
@@ -1065,6 +1558,15 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "supports-color": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -1081,6 +1583,18 @@
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       }
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha",
+    "lint": "eslint index.js lib commands"
   },
   "repository": {
     "type": "git",
@@ -24,5 +25,9 @@
     "mongodb": "^2.2.33",
     "pino": "^4.8.0",
     "sqlite": "^2.8.0"
+  },
+  "devDependencies": {
+    "mocha": "^4.0.1",
+    "rewire": "^3.0.1"
   }
 }

--- a/test/event-cmd.js
+++ b/test/event-cmd.js
@@ -1,15 +1,24 @@
 const assert = require('assert');
 const rewire = require('rewire');
 const Event = rewire('../lib/event.js');
-const CreateCommand = require('../commands/event/create');
-const ShowCommand = require('../commands/event/show');
 const prefix = require('../config').prefix;
 const {Client, Message} = require('./lib/mock.js');
 const { getClient } = require('./lib/mongo.js');
 
+const CreateCommand = require('../commands/event/create');
+const ShowCommand = require('../commands/event/show');
+const HideCommand  = require('../commands/event/hide');
+const ListCommand  = require('../commands/event/list');
+const CheckInListCommand = require('../commands/event/checkInList');
+const RegistrationListCommand = require('../commands/event/registrationList');
+const OpenRegistrationCommand = require('../commands/event/openRegistration');
+const CloseRegistration = require('../commands/event/closeRegistration');
+const CloseCheckInCommand = require('../commands/event/closeCheckin');
+const OpenCheckInCommand  = require('../commands/event/openCheckIn');
+
 const client = new Client();
 const msg = new Message();
-const eventName = 'test event';
+const eventName = 'test----event';
 
 const getCollection = function () {
     return getClient(Event).collection('events');
@@ -45,40 +54,73 @@ describe('Event commands', function () {
         });
     });
 
-    describe(getCmdName('event-show'), function () {
+    describe('Event visibility', function () {
 
-        const cmd = new ShowCommand(client);
-        let event, latestEvent; 
+        let event, latestEvent;
 
         before(async function () {
             event = await Event.create('Old');
             latestEvent = await Event.create(eventName);
         });
 
-        it('Should find an event and set it to visible if the name is provided.', async function () {
-            await cmd.run(msg, { name: event.name });
-            const eventRecord = await getCollection().findOne({ _id: event._id });
-            assert.ok(eventRecord.visible);
+        describe(getCmdName('event-show'), function () {
+
+            const cmd = new ShowCommand(client);
+
+            it('Should find an event and set it to visible if the name is provided.', async function () {
+                await cmd.run(msg, { name: event.name });
+                const eventRecord = await getCollection().findOne({ _id: event._id });
+                assert.ok(eventRecord.visible);
+            });
+
+            it('Should find the latest event and set it to visible if no name is provided.', async function () {
+                const collection = getCollection();
+
+                await collection.updateOne({ _id: latestEvent._id}, {$set: {visible: false }});
+
+                await collection.updateMany({ _id: {$in: [
+                    latestEvent._id, event._id
+                ]}}, {$set: {'status.registration': Event.STATUS.OPEN }});
+
+                await cmd.run(msg, { name: '' });
+
+                const eventRecord = await collection.findOne({ _id: latestEvent._id });
+                assert.ok(eventRecord.visible);
+            });
+
+            it('Should find return a message if no event is found for the given name.', async function () {
+                const result = await cmd.run(msg, { name: 'some nonexistent event'});
+                assert.strictEqual('Sorry, but I could not find the event.', result);
+            });
+
         });
 
-        it('Should find the latest event and set it to visible if no name is provided.', async function () {
-            const collection = getCollection();
+        describe(getCmdName('event-hide'), function () {
 
-            await collection.updateOne({ _id: latestEvent._id}, {$set: {visible: false }});
+            const cmd = new HideCommand(client);
 
-            await collection.updateMany({ _id: {$in: [
-                latestEvent._id, event._id 
-            ]}}, {$set: {'status.registration': Event.STATUS.OPEN }});
+            before(async function () {
+                await event.show();
+                await latestEvent.show();
+            });
 
-            await cmd.run(msg, { name: '' });
+            it('Should hide the event when a valid name is provided', async function () {
+                await cmd.run(msg, {name: event.name});
+                const eventRecord = await getCollection().findOne({ _id: event._id});
+                assert.ok(!eventRecord.visible);
+            });
 
-            const eventRecord = await collection.findOne({ _id: latestEvent._id }); 
-            assert.ok(eventRecord.visible);
-        });
+            it('Should hide the the latest event when no name is provided', async function () {
+                await cmd.run(msg, {name: ''});
+                const eventRecord = await getCollection().findOne({ _id: latestEvent. _id });
+                assert.ok(!eventRecord.visible);
+            });
 
-        it('Should find return a message if no event is found for the given name.', async function () {
-            const result = await cmd.run(msg, { name: 'some nonexistent event'});
-            assert.strictEqual('Sorry, but I could not find the event.', result);
+            it('Should just return a message when no event is found', async function () {
+                const result = await cmd.run(msg, {name: 'ThereIsNoEventNamedLikeThis'});
+                assert.strictEqual(result, 'Sorry, but I could not find the event.');
+            });
+
         });
 
         after(async function() {
@@ -86,4 +128,318 @@ describe('Event commands', function () {
         });
     });
 
+    describe(getCmdName('event-list'), function () {
+
+        const cmd = new ListCommand(client);
+        let event;
+
+        before(async function () {
+            event = await Event.create(eventName);
+            await event.show();
+        });
+
+        it('Should list upcoming events (those events which have visible set to true)', async function () {
+            const result = await cmd.run(msg);   
+            assert.ok(result.hasOwnProperty('embed'));
+
+            const fields = result.embed.fields;
+            assert.ok(fields[0].value.includes(event.name));
+            assert.ok(fields[1].value.includes(event.status.registration));
+            assert.ok(fields[2].value.includes(event.status.checkIn));
+        });
+
+        it('Should return a message if no events are upcoming', async function () {
+            // FIXME: Perhaps add a variable to config like "production" which skips this test.
+            // otherwise, all events in db will be set to invisible.
+            await getCollection().updateMany({}, {
+                $set: { visible: false }
+            });
+            assert.strictEqual(await cmd.run(msg), 'Sorry, there are no upcoming events.');   
+
+        });
+
+        after(async function() {
+            deleteEvents(event._id);
+            // FIXME: Needs to respect "production" variable
+            await getCollection().updateMany({}, {
+                $set: { visible: true }
+            });
+        });
+    });
+
+    describe('Registered and checked in player lists', function () {
+
+        let event, latestEvent, emptyEvent;
+        const player = {
+            'discordid' : '1234567890',
+            'discordnick' : 'testplayer',
+            'steamid64' : '12345678970',
+            'maxmmr' : 1000,
+            'checkedIn' : true
+        };
+
+        before(async function () {
+
+            event = await Event.create(eventName);
+            emptyEvent = await Event.create('Empty----event');
+            latestEvent = await Event.create('Relevant----event');
+
+            await getCollection().updateMany({ _id: {$in: [event._id, latestEvent. _id] }}, {
+                $push: {'players': player},
+                $set: {
+                    'status.registration': Event.STATUS.OPEN,
+                    'status.checkIn': Event.STATUS.OPEN,
+                    'visible': true
+                }
+            });
+        });
+
+        describe(getCmdName('event-registration-list'), function () {
+
+            const cmd = new RegistrationListCommand(client); 
+
+            it('Should show the players registered for the specified event if the name is provided', async function () {
+                const result = await cmd.run(msg, {name: event.name});
+                assert.ok(result.hasOwnProperty('embed'));
+
+                const fields = result.embed.fields;
+                assert.strictEqual(fields[0].value, 'testplayer');
+                assert.strictEqual(fields[1].value, '1000');
+            });
+
+            it('Should show the players registered for the latest event no name is provided', async function () {
+                const result = await cmd.run(msg, {name: ''});
+                assert.ok(result.hasOwnProperty('embed'));
+                assert.ok(result.embed.title.includes(latestEvent.name));
+            });
+
+            it('Should show a message if the event wasn\'t found or is invisible', async function () {
+                assert.strictEqual(
+                    await cmd.run(msg, {name: 'This event doesn\'t exist'}),
+                    'Sorry, but I could not find the event.'
+                );
+            });
+
+            it('Should show a message if the event doesn\'t have any registered Players', async function () {
+                await getCollection().updateOne({ _id: emptyEvent._id}, { $set: {
+                    'visible': true,
+                    'status.registration': Event.STATUS.OPEN,
+                }});
+
+                assert.strictEqual(
+                    await cmd.run(msg, {name: emptyEvent.name}),
+                    'There are no players registered for this event.'
+                );
+            });
+        });
+
+        describe(getCmdName('event-check-in-list'), function () {
+
+            const cmd = new CheckInListCommand(client); 
+
+            it('Should list checked in players if name is provided', async function () {
+                const result = await cmd.run(msg, {name: event.name});
+                assert.ok(result.hasOwnProperty('embed'));
+
+                const fields = result.embed.fields;
+                assert.strictEqual(fields[0].value, 'testplayer');
+                assert.strictEqual(fields[1].value, '1000');
+            });
+
+            it('Should list checked in players to the latest event if no name is provided', async function () {
+                const result = await cmd.run(msg, {name: ''});
+                assert.ok(result.hasOwnProperty('embed'));
+                assert.ok(result.embed.title.includes(latestEvent.name));
+            });
+
+            it('Should return a message if no event was found provided', async function () {
+                assert.strictEqual(
+                    await cmd.run(msg, {name: 'This event doesn\'t exist'}),
+                    'Sorry, but I could not find the event.'
+                );
+            });
+
+            it('Should return a message if event doesn\'t have any players checked in', async function () {
+                await getCollection().updateOne({ _id: event._id }, {
+                    $set: { 'players.0.checkedIn': false }
+                });
+
+                assert.strictEqual(
+                    await cmd.run(msg, {name: event.name}),
+                    'There are no players checked in for this tournament.'
+                );
+            });
+        });
+
+        after(async function() {
+            deleteEvents(event._id, latestEvent._id, emptyEvent._id);
+        });
+
+    });
+
+    describe(getCmdName('event-registration-open'), function () {
+
+        const cmd = new OpenRegistrationCommand(client);
+        let event;
+
+        before(async function () {
+            event = await Event.create(eventName);
+            await getCollection().updateOne({$id: event._id}, {
+                $set: {
+                    'status.registration': Event.STATUS.CLOSED
+                }
+            });
+        });
+
+        it('Should open the registration for the specified event', async function () {
+            await cmd.run(msg, {name: event.name});
+            let eventRecord = await getCollection().findOne({ _id: event._id });
+            assert.strictEqual(eventRecord.status.registration, Event.STATUS.OPEN);
+        });
+
+        it('Should return a message if the event isn\'t found', async function () {
+            assert.strictEqual(
+                await cmd.run(msg, {name: 'ThisIsProbablyAnEventWhichDoesn\'tExist'}),
+                'Sorry, but I could not find the event.'
+            );
+        });
+
+        after(async function() {
+            deleteEvents(event._id);
+        });
+    });
+
+    describe(getCmdName('event-registration-close'), function () {
+
+        const cmd = new CloseRegistration(client);
+        let event, latestEvent;
+
+        before(async function () {
+            event = await Event.create(eventName);
+            latestEvent = await Event.create('latest---event');
+            await getCollection().updateMany({_id: {$in: [event._id, latestEvent]}}, {$set: {
+                'visible': true,
+                'status.registration': Event.STATUS.OPEN
+            }});
+        });
+
+        it('Should close the registration for the specified event', async function () {
+            await cmd.run(msg, {name: event.name});
+            const eventRecord = await getCollection().findOne({ _id: event._id});
+            assert.strictEqual(eventRecord.status.registration, Event.STATUS.CLOSED);
+        });
+
+        it('Should close the registration for the current event if no name is provided', async function () {
+            await cmd.run(msg, {name: ''});
+            const eventRecord = await getCollection().findOne({ _id: latestEvent._id});
+            assert.strictEqual(eventRecord.status.registration, Event.STATUS.CLOSED);
+        });
+
+        it('Should return a message if no event is found', async function () {
+            assert.strictEqual(
+                await cmd.run(msg, {name: 'ThisEventDefinitelyDoesn\'tExist'}),
+                'Sorry, but I could not find the event.'
+            );
+        });
+
+        after(async function() {
+            deleteEvents(event._id, latestEvent._id);
+        });
+    });
+
+    describe(getCmdName('event-check-in-close'), function () {
+        const cmd = new CloseCheckInCommand(client);
+        let event, latestEvent;
+
+        before(async function () {
+            event = await Event.create(eventName);
+            latestEvent = await Event.create('latest---event');
+            await getCollection().updateMany({_id: {$in: [event._id, latestEvent]}}, {$set: {
+                'visible': true,
+                'status.registration': Event.STATUS.OPEN,
+                'status.checkIn': Event.STATUS.OPEN
+            }});
+        });
+
+        it('Should close the checkin for the specified event', async function () {
+            await cmd.run(msg, {name: eventName});
+            const eventEntry = await getCollection().findOne({_id: event. _id});
+            assert.strictEqual(eventEntry.status.checkIn, Event.STATUS.CLOSED);
+        });
+
+        it('Should close the checkin for the current event if the name isn\'t provided', async function () {
+            await cmd.run(msg, {name: ''});
+            const eventRecord = await getCollection().findOne({ _id: latestEvent._id});
+            assert.strictEqual(eventRecord.status.registration, Event.STATUS.CLOSED);
+        });
+
+        it('Should return a message if the event wasn\'t found', async function () {
+            assert.strictEqual(
+                await cmd.run(msg, {name: 'ThisEventDefinitelyDoesn\'tExist'}),
+                'Sorry, but I could not find the event.'
+            );
+        });
+
+        after(async function() {
+            deleteEvents(event._id, latestEvent._id);
+        });
+    });
+
+    describe(getCmdName('event-check-in-open'), function () {
+
+        const cmd = new OpenCheckInCommand(client);
+        let event, latestEvent;
+
+        before(async function () {
+            event = await Event.create(eventName);
+            latestEvent = await Event.create('latest---event');
+            await getCollection().updateMany({_id: {$in: [event._id, latestEvent._id]}}, {$set: {
+                'visible': true,
+                'status.registration': Event.STATUS.OPEN,
+                'status.checkIn': Event.STATUS.CLOSED
+            }});
+        });
+
+        it('Should open the checkin for the specified event', async function () {
+            await cmd.run(msg, {name: event.name});
+            const eventEntry = await getCollection().findOne({ _id: event._id });
+            assert.strictEqual(eventEntry.status.checkIn, Event.STATUS.OPEN);
+        });
+
+        it('Should open the checkin for the current event if the name isn\'t specified', async function () {
+            await cmd.run(msg, {name: ''});
+            const eventEntry = await getCollection().findOne({ _id: latestEvent._id });
+            assert.strictEqual(eventEntry.status.checkIn, Event.STATUS.OPEN);
+        });
+
+        it('Should return a message if the event wasn\'t found', async function () {
+            assert.strictEqual(
+                await cmd.run(msg, {name: 'ThisEventDefinitelyDoesn\'tExist'}),
+                'Sorry, but I could not find the event.'
+            );
+        });
+
+        after(async function() {
+            deleteEvents(event._id, latestEvent._id);
+        });
+    });
+});
+
+describe('Player commands', function () {
+
+    describe(getCmdName('link-steam'), function () {
+        it('Should link the players steamid64 to their discord id');
+    });
+
+    describe(getCmdName('unlink-steam'), function () {
+        it('Should unlink the players steamid64 from their discord id');
+    });
+
+    describe(getCmdName('event-register'), function () {
+        it('Should register the player to the event');
+    });
+
+    describe(getCmdName('event-check-in'), function () {
+        it('Should check the player in to the event');
+    });
 });

--- a/test/event-cmd.js
+++ b/test/event-cmd.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const rewire = require('rewire');
+const Event = rewire('../lib/event.js');
+const CreateCommand = require('../commands/event/create.js');
+const prefix = require('../config').prefix;
+const {Client, Message} = require('./lib/mock.js');
+const { getClient } = require('./lib/mongo.js');
+
+const client = new Client();
+
+const getCollection = function () {
+    return getClient(Event).collection('events');
+};
+
+const getCmdName = function (cmd) {
+    return `${prefix}${cmd}`;
+};
+
+describe('Event commands', function () {
+
+    describe(getCmdName('event-create'), function () {
+
+        let eventName = 'test event';
+
+        it('Should create an event with the supplied name', async function () {
+            let cmd = new CreateCommand(client);
+            let result = await cmd.run(new Message(), { name: eventName });
+            let eventEntry = await getCollection().findOne({ name: eventName });
+
+            assert.ok(result.includes(eventName));
+            assert.ok(eventEntry);
+            assert.strictEqual(eventEntry.name, eventName);
+        });
+
+        after(async function () {
+            await getCollection().findOneAndDelete({ name: eventName });
+        });
+    });
+
+});

--- a/test/event-cmd.js
+++ b/test/event-cmd.js
@@ -1,12 +1,15 @@
 const assert = require('assert');
 const rewire = require('rewire');
 const Event = rewire('../lib/event.js');
-const CreateCommand = require('../commands/event/create.js');
+const CreateCommand = require('../commands/event/create');
+const ShowCommand = require('../commands/event/show');
 const prefix = require('../config').prefix;
 const {Client, Message} = require('./lib/mock.js');
 const { getClient } = require('./lib/mongo.js');
 
 const client = new Client();
+const msg = new Message();
+const eventName = 'test event';
 
 const getCollection = function () {
     return getClient(Event).collection('events');
@@ -16,15 +19,20 @@ const getCmdName = function (cmd) {
     return `${prefix}${cmd}`;
 };
 
+const deleteEvents = function (...ids) {
+    return getCollection().deleteMany({ _id: {
+        $in: ids
+    }});
+};
+
 describe('Event commands', function () {
 
     describe(getCmdName('event-create'), function () {
 
-        let eventName = 'test event';
 
         it('Should create an event with the supplied name', async function () {
             let cmd = new CreateCommand(client);
-            let result = await cmd.run(new Message(), { name: eventName });
+            let result = await cmd.run(msg, { name: eventName });
             let eventEntry = await getCollection().findOne({ name: eventName });
 
             assert.ok(result.includes(eventName));
@@ -34,6 +42,47 @@ describe('Event commands', function () {
 
         after(async function () {
             await getCollection().findOneAndDelete({ name: eventName });
+        });
+    });
+
+    describe(getCmdName('event-show'), function () {
+
+        const cmd = new ShowCommand(client);
+        let event, latestEvent; 
+
+        before(async function () {
+            event = await Event.create('Old');
+            latestEvent = await Event.create(eventName);
+        });
+
+        it('Should find an event and set it to visible if the name is provided.', async function () {
+            await cmd.run(msg, { name: event.name });
+            const eventRecord = await getCollection().findOne({ _id: event._id });
+            assert.ok(eventRecord.visible);
+        });
+
+        it('Should find the latest event and set it to visible if no name is provided.', async function () {
+            const collection = getCollection();
+
+            await collection.updateOne({ _id: latestEvent._id}, {$set: {visible: false }});
+
+            await collection.updateMany({ _id: {$in: [
+                latestEvent._id, event._id 
+            ]}}, {$set: {'status.registration': Event.STATUS.OPEN }});
+
+            await cmd.run(msg, { name: '' });
+
+            const eventRecord = await collection.findOne({ _id: latestEvent._id }); 
+            assert.ok(eventRecord.visible);
+        });
+
+        it('Should find return a message if no event is found for the given name.', async function () {
+            const result = await cmd.run(msg, { name: 'some nonexistent event'});
+            assert.strictEqual('Sorry, but I could not find the event.', result);
+        });
+
+        after(async function() {
+            deleteEvents(event._id, latestEvent._id);
         });
     });
 

--- a/test/event.js
+++ b/test/event.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+const rewire = require('rewire');
+const event = rewire('../lib/event');
+const { getClient } = require('./lib/mongo');
+
+const getEventClient = function () {
+    return getClient(event);
+};
+
+const getCollection = function () {
+    return getEventClient().collection('events');
+};
+
+describe('Event', function() {
+
+    describe('#create()', function() {
+        it('should create a new Event', async function () {
+            let eventName = 'Test event',
+                collection = getCollection(),
+                eventCount = await collection.count(),
+                e;
+
+            e = await event.create(eventName);
+            assert.equal(await collection.count(), eventCount + 1);
+            assert.equal(eventName, e.name);
+
+            // Cleanup
+            collection.deleteOne({_id: e._id});
+        });
+    });
+
+    describe('#findById()', function() {
+        it('should be able to find an event by an ID');
+    });
+
+    describe('#findByName()', function() {
+        it('should be able to find an event by an ID');
+    });
+
+    describe('#findCurrentEvent()', function() {
+        it('should be able to find the latest open and visible event');
+    });
+
+    describe('#findVisible()', function() {
+        it('should be able to find only visible events');
+    });
+
+    describe('#openRegistration()', function() {
+        it('should open registrations for the current event');
+    });
+
+    describe('#closeRegistration()', function() {
+        it('should close registrations for the current event');
+    });
+
+    describe('#openCheckIn()', function() {
+        it('should open checkIn for the current event');
+    });
+
+    describe('#closeCheckIn()', function() {
+        it('should close checkIn for the current event');
+    });
+
+    describe('#show()', function() {
+        it('should set the current event to visible');
+    });
+
+    describe('#hide()', function() {
+        it('should set the current event to hidden');
+    });
+
+    describe('#hasRegistered()', function() {
+        it('should check if the player supplied is registered');
+    });
+
+    describe('#register()', function() {
+        it('should register the supplied player');
+    });
+
+    describe('#checkIn()', function() {
+        it('should checkin the supplied player');
+    });
+
+    describe('#getRegisteredPlayers()', function() {
+        it('should return the players registered for this event');
+    });
+
+    describe('#getCheckedInPlayers()', function() {
+        it('should return the players registered for this event');
+    });
+
+    describe('#playerIsRegistered()', function() {
+        it('should return if the supplied player is registered');
+    });
+
+    after(function () {
+        // Close database connection, so process ends cleanly
+        getEventClient().client.close();
+    });
+});

--- a/test/event.js
+++ b/test/event.js
@@ -397,9 +397,4 @@ describe('Event', function() {
             deleteEvents(e._id);
         });
     });
-
-    after(function () {
-        // Close database connection, so process ends cleanly
-        getEventClient().client.close();
-    });
 });

--- a/test/event.js
+++ b/test/event.js
@@ -11,6 +11,12 @@ const getCollection = function () {
     return getEventClient().collection('events');
 };
 
+const deleteEvents = function (...ids) {
+    return getCollection().deleteMany({ _id: {
+        $in: ids
+    }});
+};
+
 describe('Event', function() {
 
     describe('#create()', function() {
@@ -21,52 +27,206 @@ describe('Event', function() {
                 e;
 
             e = await event.create(eventName);
-            assert.equal(await collection.count(), eventCount + 1);
-            assert.equal(eventName, e.name);
 
-            // Cleanup
-            collection.deleteOne({_id: e._id});
+            assert.equal(await collection.count(), eventCount + 1, 'Event count doesn\'t match');
+            assert.equal(eventName, e.name, 'Event was created with incorrect name');
+            assert.ok(e instanceof event, 'create() didn\'t return an Event instance');
+
+            deleteEvents(e._id);
         });
     });
 
     describe('#findById()', function() {
-        it('should be able to find an event by an ID');
+        it('should be able to find an event by an ID', async function () {
+            let e = await event.create('Test event');
+            let e2 = await event.findById(e._id);
+            deleteEvents(e._id, e2._id);
+
+            assert.equal(e._id.toString(), e2._id.toString(), 'Event names don\'t match');
+            assert.ok(e2 instanceof event, 'findById() didn\'t return an Event instance');
+
+        });
     });
 
     describe('#findByName()', function() {
-        it('should be able to find an event by an ID');
+        it('should be able to find an event by an name', async function () {
+            let eventName = 'Test event';
+            let e = await event.create(eventName);
+            let e2 = await event.findByName(eventName);
+            deleteEvents(e._id);
+
+            assert.equal(e.name, e2.name, 'Names do not match.');
+            assert.ok(e2 instanceof event, 'findByName doesn\'t return an event');
+        });
     });
 
     describe('#findCurrentEvent()', function() {
-        it('should be able to find the latest open and visible event');
+        it('should be able to find the latest open and visible event', async function () {
+            // TODO: Refactor this when event creation timestamps are added.
+            let e = await event.create('Test event');
+
+            await e.show();
+            await e.openRegistration();
+
+            let eCurrent = await event.findCurrentEvent();
+
+            assert.equal(eCurrent._id.toString(), e._id.toString(), 'Returned event isn\'t the current one');
+            assert.ok(eCurrent instanceof event, 'findCurrentEvent() didn\'t return an Event instance');
+
+            deleteEvents(eCurrent._id);
+        });
     });
 
     describe('#findVisible()', function() {
-        it('should be able to find only visible events');
+        it('should be able to find only visible events', async function () {
+            let collection = getCollection();
+            let visibleEventCount = await collection.count({ visible: true });
+            let e = await event.create('Test event');
+            let e2;
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {visible: false}
+            });
+
+            let visibleEvents = await event.findVisible();
+
+            assert.equal(visibleEventCount, visibleEvents.length, 'Visible event count is incorrect');
+
+            // Update created event to visible and check if "findVisible()" contains Event instances
+            // That way we also check if newest event is first
+            await collection.updateOne({ _id: e._id }, {
+                $set: {visible: true}
+            });
+
+            visibleEvents = await event.findVisible();
+            e2 = visibleEvents[0];
+
+            assert.equal(e._id.toString(), e2._id.toString(), 'Incorrect ordering of events returned');
+            assert.ok(e2 instanceof event, 'findVisible() doesn\'t return Event instances');
+
+            deleteEvents(e._id);
+
+        });
     });
 
     describe('#openRegistration()', function() {
-        it('should open registrations for the current event');
+        it('should open registrations for the current event', async function () {
+            let e = await event.create('Test event');
+            let collection = getCollection();
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {'status.registration': event.STATUS.CLOSED}
+            });
+            await e.openRegistration();
+
+            assert.equal(e.status.registration, event.STATUS.OPEN);
+
+            // Check if database entry corresponds to the Event object
+            let e2 = await collection.findOne({ _id: e._id });
+            assert.equal(e.status.registration, e2.status.registration);
+
+            deleteEvents(e._id);
+        });
     });
 
     describe('#closeRegistration()', function() {
-        it('should close registrations for the current event');
+        it('should close registrations for the current event', async function () {
+            let e = await event.create('Test event');
+            let collection = getCollection();
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {'status.registration': event.STATUS.OPEN}
+            });
+            await e.closeRegistration();
+
+            assert.equal(e.status.registration, event.STATUS.CLOSED);
+
+            // Check if database entry corresponds to the Event object
+            let e2 = await collection.findOne({ _id: e._id });
+            assert.equal(e.status.registration, e2.status.registration);
+
+            deleteEvents(e._id);
+        });
     });
 
     describe('#openCheckIn()', function() {
-        it('should open checkIn for the current event');
+        it('should open checkIn for the current event', async function () {
+            let e = await event.create('Test event');
+            let collection = getCollection();
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {'status.checkIn': event.STATUS.CLOSED}
+            });
+            await e.openCheckIn();
+
+            assert.equal(e.status.checkIn, event.STATUS.OPEN);
+
+            // Check if database entry corresponds to the Event object
+            let e2 = await collection.findOne({ _id: e._id });
+            assert.equal(e.status.checkIn, e2.status.checkIn);
+
+            deleteEvents(e._id);
+        });
     });
 
     describe('#closeCheckIn()', function() {
-        it('should close checkIn for the current event');
+        it('should close checkIn for the current event', async function () {
+            let e = await event.create('Test event');
+            let collection = getCollection();
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {'status.checkIn': event.STATUS.OPEN}
+            });
+            await e.closeCheckIn();
+
+            assert.equal(e.status.checkIn, event.STATUS.CLOSED);
+
+            // Check if database entry corresponds to the Event object
+            let e2 = await collection.findOne({ _id: e._id });
+            assert.equal(e.status.checkIn, e2.status.checkIn);
+
+            deleteEvents(e._id);
+        });
     });
 
     describe('#show()', function() {
-        it('should set the current event to visible');
+        it('should set the current event to visible', async function () {
+            let e = await event.create('Test event');
+            let collection = getCollection();
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {'visible': false}
+            });
+            await e.show();
+
+            assert.equal(e.visible, true);
+
+            // Check if database entry corresponds to the Event object
+            let e2 = await collection.findOne({ _id: e._id });
+            assert.equal(e.visible, e2.visible);
+
+            deleteEvents(e._id);
+        });
     });
 
     describe('#hide()', function() {
-        it('should set the current event to hidden');
+        it('should set the current event to hidden', async function () {
+            let e = await event.create('Test event');
+            let collection = getCollection();
+
+            await collection.updateOne({ _id: e._id }, {
+                $set: {'visible': true}
+            });
+            await e.hide();
+
+            assert.equal(e.visible, false);
+
+            // Check if database entry corresponds to the Event object
+            let e2 = await collection.findOne({ _id: e._id });
+            assert.equal(e.visible, e2.visible);
+
+            deleteEvents(e._id);
+        });
     });
 
     describe('#hasRegistered()', function() {

--- a/test/event.js
+++ b/test/event.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const rewire = require('rewire');
 const event = rewire('../lib/event');
+const Player = require('../lib/player');
 const { getClient } = require('./lib/mongo');
 
 const getEventClient = function () {
@@ -17,50 +18,69 @@ const deleteEvents = function (...ids) {
     }});
 };
 
-describe('Event', function() {
+const createPlayer = function () {
+    return new Player({
+        discordid: '1234567890',
+        discordnick: 'testplayer',
+        steamid64: '1234567890',
+        maxmmr: 1000
+    });
+};
 
+describe('Event', function() {
     describe('#create()', function() {
+        let e;
         it('should create a new Event', async function () {
             let eventName = 'Test event',
                 collection = getCollection(),
-                eventCount = await collection.count(),
-                e;
+                eventCount = await collection.count();
 
             e = await event.create(eventName);
 
-            assert.equal(await collection.count(), eventCount + 1, 'Event count doesn\'t match');
-            assert.equal(eventName, e.name, 'Event was created with incorrect name');
+            assert.strictEqual(await collection.count(), eventCount + 1, 'Event count doesn\'t match');
+            assert.strictEqual(eventName, e.name, 'Event was created with incorrect name');
             assert.ok(e instanceof event, 'create() didn\'t return an Event instance');
+        });
 
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
     describe('#findById()', function() {
+        let e, e2;
         it('should be able to find an event by an ID', async function () {
-            let e = await event.create('Test event');
-            let e2 = await event.findById(e._id);
-            deleteEvents(e._id, e2._id);
+            e = await event.create('Test event');
+            e2 = await event.findById(e._id);
 
-            assert.equal(e._id.toString(), e2._id.toString(), 'Event names don\'t match');
+            assert.strictEqual(e._id.toString(), e2._id.toString(), 'Event names don\'t match');
             assert.ok(e2 instanceof event, 'findById() didn\'t return an Event instance');
 
+        });
+
+        after(function () {
+            deleteEvents(e._id, e2._id);
         });
     });
 
     describe('#findByName()', function() {
+        let e;
         it('should be able to find an event by an name', async function () {
             let eventName = 'Test event';
-            let e = await event.create(eventName);
+            e = await event.create(eventName);
             let e2 = await event.findByName(eventName);
-            deleteEvents(e._id);
 
-            assert.equal(e.name, e2.name, 'Names do not match.');
+            assert.strictEqual(e.name, e2.name, 'Names do not match.');
             assert.ok(e2 instanceof event, 'findByName doesn\'t return an event');
+        });
+
+        after(function () {
+            deleteEvents(e._id);
         });
     });
 
     describe('#findCurrentEvent()', function() {
+        let eCurrent;
         it('should be able to find the latest open and visible event', async function () {
             // TODO: Refactor this when event creation timestamps are added.
             let e = await event.create('Test event');
@@ -68,21 +88,25 @@ describe('Event', function() {
             await e.show();
             await e.openRegistration();
 
-            let eCurrent = await event.findCurrentEvent();
+            eCurrent = await event.findCurrentEvent();
 
-            assert.equal(eCurrent._id.toString(), e._id.toString(), 'Returned event isn\'t the current one');
+            assert.strictEqual(eCurrent._id.toString(), e._id.toString(), 'Returned event isn\'t the current one');
             assert.ok(eCurrent instanceof event, 'findCurrentEvent() didn\'t return an Event instance');
+        });
 
+        after(function () {
             deleteEvents(eCurrent._id);
         });
     });
 
     describe('#findVisible()', function() {
+        let e;
         it('should be able to find only visible events', async function () {
             let collection = getCollection();
             let visibleEventCount = await collection.count({ visible: true });
-            let e = await event.create('Test event');
             let e2;
+
+            e = await event.create('Test event');
 
             await collection.updateOne({ _id: e._id }, {
                 $set: {visible: false}
@@ -90,7 +114,7 @@ describe('Event', function() {
 
             let visibleEvents = await event.findVisible();
 
-            assert.equal(visibleEventCount, visibleEvents.length, 'Visible event count is incorrect');
+            assert.strictEqual(visibleEventCount, visibleEvents.length, 'Visible event count is incorrect');
 
             // Update created event to visible and check if "findVisible()" contains Event instances
             // That way we also check if newest event is first
@@ -101,77 +125,92 @@ describe('Event', function() {
             visibleEvents = await event.findVisible();
             e2 = visibleEvents[0];
 
-            assert.equal(e._id.toString(), e2._id.toString(), 'Incorrect ordering of events returned');
+            assert.strictEqual(e._id.toString(), e2._id.toString(), 'Incorrect ordering of events returned');
             assert.ok(e2 instanceof event, 'findVisible() doesn\'t return Event instances');
+        });
 
+        after(function () {
             deleteEvents(e._id);
-
         });
     });
 
     describe('#openRegistration()', function() {
+        let e;
         it('should open registrations for the current event', async function () {
-            let e = await event.create('Test event');
             let collection = getCollection();
+
+            e = await event.create('Test event');
 
             await collection.updateOne({ _id: e._id }, {
                 $set: {'status.registration': event.STATUS.CLOSED}
             });
             await e.openRegistration();
 
-            assert.equal(e.status.registration, event.STATUS.OPEN);
+            assert.strictEqual(e.status.registration, event.STATUS.OPEN);
 
             // Check if database entry corresponds to the Event object
             let e2 = await collection.findOne({ _id: e._id });
-            assert.equal(e.status.registration, e2.status.registration);
+            assert.strictEqual(e.status.registration, e2.status.registration);
 
+        });
+
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
     describe('#closeRegistration()', function() {
+        let e;
         it('should close registrations for the current event', async function () {
-            let e = await event.create('Test event');
             let collection = getCollection();
+
+            e = await event.create('Test event');
 
             await collection.updateOne({ _id: e._id }, {
                 $set: {'status.registration': event.STATUS.OPEN}
             });
             await e.closeRegistration();
 
-            assert.equal(e.status.registration, event.STATUS.CLOSED);
+            assert.strictEqual(e.status.registration, event.STATUS.CLOSED);
 
             // Check if database entry corresponds to the Event object
             let e2 = await collection.findOne({ _id: e._id });
-            assert.equal(e.status.registration, e2.status.registration);
+            assert.strictEqual(e.status.registration, e2.status.registration);
+        });
 
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
     describe('#openCheckIn()', function() {
+        let e;
         it('should open checkIn for the current event', async function () {
-            let e = await event.create('Test event');
             let collection = getCollection();
+
+            e = await event.create('Test event');
 
             await collection.updateOne({ _id: e._id }, {
                 $set: {'status.checkIn': event.STATUS.CLOSED}
             });
             await e.openCheckIn();
 
-            assert.equal(e.status.checkIn, event.STATUS.OPEN);
+            assert.strictEqual(e.status.checkIn, event.STATUS.OPEN);
 
             // Check if database entry corresponds to the Event object
             let e2 = await collection.findOne({ _id: e._id });
-            assert.equal(e.status.checkIn, e2.status.checkIn);
+            assert.strictEqual(e.status.checkIn, e2.status.checkIn);
+        });
 
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
     describe('#closeCheckIn()', function() {
+        let e;
         it('should close checkIn for the current event', async function () {
-            let e = await event.create('Test event');
+            e = await event.create('Test event');
             let collection = getCollection();
 
             await collection.updateOne({ _id: e._id }, {
@@ -179,19 +218,24 @@ describe('Event', function() {
             });
             await e.closeCheckIn();
 
-            assert.equal(e.status.checkIn, event.STATUS.CLOSED);
+            assert.strictEqual(e.status.checkIn, event.STATUS.CLOSED);
 
             // Check if database entry corresponds to the Event object
             let e2 = await collection.findOne({ _id: e._id });
-            assert.equal(e.status.checkIn, e2.status.checkIn);
+            assert.strictEqual(e.status.checkIn, e2.status.checkIn);
 
+            deleteEvents(e._id);
+        });
+
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
     describe('#show()', function() {
+        let e;
         it('should set the current event to visible', async function () {
-            let e = await event.create('Test event');
+            e = await event.create('Test event');
             let collection = getCollection();
 
             await collection.updateOne({ _id: e._id }, {
@@ -199,19 +243,24 @@ describe('Event', function() {
             });
             await e.show();
 
-            assert.equal(e.visible, true);
+            assert.strictEqual(e.visible, true);
 
             // Check if database entry corresponds to the Event object
             let e2 = await collection.findOne({ _id: e._id });
-            assert.equal(e.visible, e2.visible);
+            assert.strictEqual(e.visible, e2.visible);
 
+            deleteEvents(e._id);
+        });
+
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
     describe('#hide()', function() {
+        let e;
         it('should set the current event to hidden', async function () {
-            let e = await event.create('Test event');
+            e = await event.create('Test event');
             let collection = getCollection();
 
             await collection.updateOne({ _id: e._id }, {
@@ -219,38 +268,134 @@ describe('Event', function() {
             });
             await e.hide();
 
-            assert.equal(e.visible, false);
+            assert.strictEqual(e.visible, false);
 
             // Check if database entry corresponds to the Event object
             let e2 = await collection.findOne({ _id: e._id });
-            assert.equal(e.visible, e2.visible);
+            assert.strictEqual(e.visible, e2.visible);
+        });
 
+        after(function () {
             deleteEvents(e._id);
         });
     });
 
-    describe('#hasRegistered()', function() {
-        it('should check if the player supplied is registered');
+    describe('Player registration', function () {
+        let e;
+        let player = createPlayer();
+        let player2;
+        describe('#register()', function() {
+            it('should register the supplied player', async function () {
+                let eventPlayer;
+
+                e = await event.create('Test event');
+
+                await e.register(player);
+
+                eventPlayer = e.players[0];
+                assert.strictEqual(eventPlayer.discordid, player.discordid);
+
+                // Check if database entry corresponds to the Event object
+                let e2 = await getCollection().findOne({ _id: e._id });
+                assert.strictEqual(e2.players.length, 1);
+                assert.strictEqual(e2.players[0].discordid, player.discordid);
+            });
+        });
+
+        describe('Registration checking', function () {
+            // Check a non-registered player
+            player2 = createPlayer();
+            player2.discordid = 'xxx';
+            describe('#hasRegistered()', function() {
+                it('should check if the player supplied is registered', async function () {
+                    // Check an actually registered player
+                    assert.ok(await e.hasRegistered(player));
+
+                    // Check an unregistered one
+                    assert.ok(!await e.hasRegistered(player2));
+                });
+            });
+
+            describe('#playerIsRegistered()', function() {
+                it('should return if the supplied player is registered', async function () {
+                    // Check an actually registered player
+                    assert.ok(await e.playerIsRegistered(player.discordid));
+
+                    // Check an unregistered one
+                    assert.ok(!await e.playerIsRegistered(player2.discordid));
+                });
+            });
+        });
+
+        describe('#getRegisteredPlayers()', function() {
+            it('should return the players registered for this event sorted by descending MMR', async function () {
+                let registeredPlayers;
+                let first;
+
+                player2.maxmmr = 1;
+                await e.register(player2);
+                registeredPlayers = await e.getRegisteredPlayers();
+
+                first = registeredPlayers[0];
+                assert.ok(first instanceof Player);
+                assert.strictEqual(first.discordid, player.discordid);
+                assert.strictEqual(registeredPlayers[1].discordid, player2.discordid);
+            });
+        });
+
+        after(function () {
+            deleteEvents(e._id);
+        });
     });
 
-    describe('#register()', function() {
-        it('should register the supplied player');
-    });
+    describe('Player checkin', function () {
+        let e;
+        let player = createPlayer();
+        let player2 = createPlayer();
+        let player3 = createPlayer();
 
-    describe('#checkIn()', function() {
-        it('should checkin the supplied player');
-    });
+        player2.maxmmr = 1;
+        player2.discordid = 'XXX';
+        player3.discordid = 'YYY';
 
-    describe('#getRegisteredPlayers()', function() {
-        it('should return the players registered for this event');
-    });
+        before(async function () {
+            e = await event.create('Test event');
+            await e.register(player);
+            await e.register(player2);
+            await e.register(player3);
+        });
 
-    describe('#getCheckedInPlayers()', function() {
-        it('should return the players registered for this event');
-    });
+        describe('#checkIn()', function() {
+            it('should checkin the supplied player', async function () {
+                await e.checkIn(player);
+                let eventWithCheckedInPlayer = await getCollection().findOne({
+                    '_id': e._id,
+                    'players.discordid': player.discordid,
+                    'players.checkedIn': true
+                });
 
-    describe('#playerIsRegistered()', function() {
-        it('should return if the supplied player is registered');
+                assert.ok(eventWithCheckedInPlayer);
+
+            });
+        });
+
+        describe('#getCheckedInPlayers()', function() {
+            it('should return the players checked in for this event ordered by descending MMR', async function () {
+                let checkedInPlayers;
+                await e.checkIn(player2);
+                checkedInPlayers = await e.getCheckedInPlayers();
+
+                let first = checkedInPlayers[0];
+                assert.ok(first instanceof Player);
+                assert.strictEqual(first.discordid, player.discordid);
+                assert.strictEqual(checkedInPlayers[1].discordid, player2.discordid);
+                assert.strictEqual(checkedInPlayers.length, 2);
+            });
+        });
+
+        after(function () {
+            deleteEvents(e._id);
+        });
     });
 
     after(function () {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,6 @@
+const mongodb = require('../lib/mongodb');
+
+after(async function () {
+    // Close database connection after all tests have run.
+    mongodb.client.close();
+});

--- a/test/lib/constants.js
+++ b/test/lib/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+    // Shared discordid by mock discord users and test players
+    discordid: '1234567890'
+};

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -15,4 +15,29 @@ class RocketLeagueAPI {
     }
 }
 
-module.exports = {RocketLeagueAPI};
+
+class Message {
+    async say(msg) {
+        return msg;
+    }
+}
+
+
+class Collection {
+    has() {
+        return true;
+    } 
+
+    get() {}
+}
+
+
+class Client {
+    constructor(options) {
+        this.registry = {
+            types: new Collection()
+        };
+    }
+}
+
+module.exports = {RocketLeagueAPI, Client, Message};

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -1,4 +1,5 @@
 const { PlayerNotFoundException } = require('../../lib/rllv-api.js');
+const constants = require('./constants');
 
 class RocketLeagueAPI {
     static async getPlayer(steamid64) {
@@ -19,6 +20,15 @@ class RocketLeagueAPI {
 class Message {
     
     constructor() {
+        this.author = {
+            id: constants.discordid,
+            username: 'mockuser' 
+        };
+
+        this.member = {
+            nickname: 'mocknickname'
+        };
+
         this.channel = {
             send: function (msg) {
                 return msg;

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -1,0 +1,18 @@
+const { PlayerNotFoundException } = require('../../lib/rllv-api.js');
+
+class RocketLeagueAPI {
+    static async getPlayer(steamid64) {
+        // If steamid64 is 1, return valid response
+        // If 0, raise exception
+        if (steamid64) {
+            return {
+                'nick':'mockplayer',
+                'maxmmr':'2000'
+            };
+        } else {
+            throw new PlayerNotFoundException('Exception raised from mock RocketLeagueAPI');
+        }
+    }
+}
+
+module.exports = {RocketLeagueAPI};

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -17,6 +17,15 @@ class RocketLeagueAPI {
 
 
 class Message {
+    
+    constructor() {
+        this.channel = {
+            send: function (msg) {
+                return msg;
+            }
+        };
+    }
+
     async say(msg) {
         return msg;
     }
@@ -34,6 +43,7 @@ class Collection {
 
 class Client {
     constructor(options) {
+        this.options = options;
         this.registry = {
             types: new Collection()
         };

--- a/test/lib/mongo.js
+++ b/test/lib/mongo.js
@@ -1,0 +1,10 @@
+module.exports = {
+    getClient: function(rewired, privVar) {
+        // gets the mongodb client instance from a rewired module.
+        //
+        // Since module.exports in lib/mongodb is mutated on connection,
+        // we need this utility function.
+        privVar = privVar || 'mongodb';
+        return rewired.__get__(privVar);
+    }
+};

--- a/test/player-list-embed.js
+++ b/test/player-list-embed.js
@@ -1,0 +1,31 @@
+const oneLine = require('common-tags').oneLine;
+const assert = require('assert');
+const {TournamentListEmbed} = require('../lib/player-list-embed');
+
+describe('TournamentListEmbed', function () {
+    describe('#getEmbed()', function () {
+        it(oneLine`
+            Should accept an array of players
+            and return an embed object where
+            the players are displayed as a table.`,
+            function () {
+                let players = [
+                    {discordnick: 'first', maxmmr: 1},
+                    {discordnick: 'second', maxmmr: 2},
+                    {discordnick: 'third', maxmmr: 3},
+                ]; 
+
+                let embedFields = new TournamentListEmbed('Some title', players).getEmbed().fields;
+                let playerMMR = [];
+                let playerNames = [];
+
+                players.forEach(player => {
+                    playerNames.push(player.discordnick);
+                    playerMMR.push(player.maxmmr);
+                });
+
+                assert.strictEqual(embedFields[0].value, playerNames.join('\n'));
+                assert.strictEqual(embedFields[1].value, playerMMR.join('\n'));
+            });
+    });
+});

--- a/test/player.js
+++ b/test/player.js
@@ -193,9 +193,4 @@ describe('Player', function () {
             deletePlayers(player._id);
         });
     });
-
-    after(function () {
-        // Close database connection, so process ends cleanly
-        getPlayerClient().client.close();
-    });
 });

--- a/test/player.js
+++ b/test/player.js
@@ -1,0 +1,43 @@
+const rewire = require('rewire');
+const Player = rewire('../lib/player');
+const { getClient } = require('./lib/mongo');
+
+const getPlayerClient = function () {
+    return getClient(Player);
+};
+
+describe('Player', function () {
+
+    describe('#create()', function () {
+        it('Should store a new player in the database and return the corresponding Player instance.');
+    });
+
+    describe('#findByDiscordId(discordid)', function () {
+        it('It should find a player in the database with the provided discord ID, and return a Player instance.');
+    });
+
+    describe('#steamId64Taken(steamid64)', function () {
+        it('It should return if the provided steamid64 is already taken.');
+    });
+
+    describe('#updateMaxMMR()', function () {
+        it('It should update the players MaxMMR by utilizing an external resource');
+    });
+
+    describe('#unsetSteamId64()', function () {
+        it('It should unset the player\'s steamid64');
+    });
+
+    describe('#setParams(params)', function () {
+        it('It should set the player\'s parameters both in the database and for the instance.');
+    });
+
+    describe('#delete()', function () {
+        it('It should delete the corresponding player entry from the database.');
+    });
+
+    after(function () {
+        // Close database connection, so process ends cleanly
+        getPlayerClient().client.close();
+    });
+});

--- a/test/player.js
+++ b/test/player.js
@@ -1,39 +1,197 @@
+const assert = require('assert');
 const rewire = require('rewire');
 const Player = rewire('../lib/player');
 const { getClient } = require('./lib/mongo');
+const mock = require('./lib/mock');
 
 const getPlayerClient = function () {
     return getClient(Player);
 };
 
+const getCollection = function () {
+    return getPlayerClient().collection('players');
+};
+
+const deletePlayers = function (...ids) {
+    return getCollection().deleteMany({ _id: {
+        $in: ids
+    }});
+};
+
+const createPlayer = async function () {
+    return await Player.create({
+        discordid: '123123',
+        discordnick: 'test player',
+        steamid64: '1234567890',
+        maxmmr: 1000
+    });
+};
+
 describe('Player', function () {
 
-    describe('#create()', function () {
-        it('Should store a new player in the database and return the corresponding Player instance.');
+    describe('#create()', async function () {
+
+        let player;
+
+        it('Should store a new player in the database and return the corresponding Player instance.', async function () {
+            player = await createPlayer();
+            assert.ok(player.hasOwnProperty('_id'));
+            assert.ok(player instanceof Player);
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     describe('#findByDiscordId(discordid)', function () {
-        it('It should find a player in the database with the provided discord ID, and return a Player instance.');
+
+        let player;
+
+        before(async function () {
+            player = await createPlayer();
+        });
+
+        it('Should find a player in the database with the provided discord ID, and return a Player instance.', async function () {
+            let playerRecord = await Player.findByDiscordId(player.discordid);
+            assert.ok(playerRecord instanceof Player);
+        });
+
+        it('Should return null if a nonexistent discord id is supplied', async function () {
+            assert.strictEqual(await Player.findByDiscordId('NotValid'), null);
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     describe('#steamId64Taken(steamid64)', function () {
-        it('It should return if the provided steamid64 is already taken.');
+
+        let player;
+
+        before(async function () {
+            player = await createPlayer();
+        });
+
+        it('It should return true if the provided steamid64 is already taken.', async function () {
+            assert.ok(await Player.steamId64Taken(player.steamid64));
+        });
+
+        it('It should return false if the provided steamid64 is available.', async function () {
+            assert.ok(!await Player.steamId64Taken('AvailableValue'));
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     describe('#updateMaxMMR()', function () {
-        it('It should update the players MaxMMR by utilizing an external resource');
+        let player;
+
+        before(async function () {
+            player = await createPlayer();
+        });
+
+        it('It should update the players MaxMMR by utilizing an external resource', function () {
+            Player.__with__({
+                rllv: mock
+            })(function () {
+                return player.updateMaxMMR();
+            }).then(async function () {
+                assert.equal(player.maxmmr, 2000);
+                const playerRecord = await getCollection().findOne({ _id: player._id });
+                assert.equal(playerRecord.maxmmr, 2000);
+            });
+        });
+
+        it('It should not raise an exception if a non-existing player is provided', function () {
+
+            let fakePlayer = new Player({
+                steamid64: 0,
+                maxmmr: 1000
+            });
+
+            Player.__with__({
+                rllv: mock
+            })(function () {
+                return fakePlayer.updateMaxMMR();
+            }).then(function () {
+                assert.equal(fakePlayer.maxmmr, 1000);
+            });
+
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     describe('#unsetSteamId64()', function () {
-        it('It should unset the player\'s steamid64');
+        let player;
+
+        before(async function () {
+            player = await createPlayer();
+        });
+
+        it('It should unset the player\'s steamid64', async function () {
+            let playerRecord;
+
+            await player.unsetSteamId64();
+
+            playerRecord = await getCollection().findOne({ _id: player._id });
+            assert.ok(!player.hasOwnProperty('steamid64'));
+            assert.ok(!playerRecord.hasOwnProperty('steamid64'));
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     describe('#setParams(params)', function () {
-        it('It should set the player\'s parameters both in the database and for the instance.');
+        let player;
+
+        before(async function () {
+            player = await createPlayer();
+        });
+
+        it('It should set the player\'s parameters both in the database and for the instance.', async function () {
+            let playerRecord;
+
+            await player.setParams({
+                discordid: '1',
+                someprop: 'string'
+            });
+
+            playerRecord = await getCollection().findOne({ _id: player._id });
+            assert.strictEqual(player.discordid, '1');
+            assert.strictEqual(player.someprop, 'string');
+            assert.strictEqual(playerRecord.discordid, '1');
+            assert.strictEqual(playerRecord.someprop, 'string');
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     describe('#delete()', function () {
-        it('It should delete the corresponding player entry from the database.');
+        let player;
+
+        before(async function () {
+            player = await createPlayer();
+        });
+
+        it('It should delete the corresponding player entry from the database.', async function () {
+            await player.delete();
+            assert.ok(!await getCollection().findOne({ _id: player._id }));
+        });
+
+        after(function () {
+            deletePlayers(player._id);
+        });
     });
 
     after(function () {

--- a/test/rlapi.js
+++ b/test/rlapi.js
@@ -1,5 +1,31 @@
+const assert = require('assert');
+const {RocketLeagueAPI, PlayerNotFoundException} = require('../lib/rllv-api.js');
+
+// Valid steamid64 for tests
+const steamid = '76561197982344715';
+
 describe('RocketLeagueAPI', function () {
     describe('#getPlayer(steamid64)', function () {
-        it('Should return the player object with the provided steamid64 from the rocketleague.lv API.');
+        it('Should return the player object with the provided steamid64 from the rocketleague.lv API.', async function () {
+            const response = await RocketLeagueAPI.getPlayer(steamid);
+
+            assert.ok(response.hasOwnProperty('nick'));
+            assert.ok(response.hasOwnProperty('maxmmr'));
+
+        });
+
+        it('Should return null if given a non-numeric argument', async function () {
+            assert.strictEqual(await RocketLeagueAPI.getPlayer('non numeric steam id'), null);
+        });
+
+        it('Should raise an error when the player isn\'t found in the database.', async function () {
+            // I couldn't use assert.raises() since unhandled Promise rejections are deprecated,
+            // but If i handle it, the exception doesn't get thrown, therefore the test fails.
+            try {
+                await RocketLeagueAPI.getPlayer('321321321321');
+            } catch (e) {
+                assert.ok(e instanceof PlayerNotFoundException);
+            }
+        });
     });
 });

--- a/test/rlapi.js
+++ b/test/rlapi.js
@@ -1,0 +1,5 @@
+describe('RocketLeagueAPI', function () {
+    describe('#getPlayer(steamid64)', function () {
+        it('Should return the player object with the provided steamid64 from the rocketleague.lv API.');
+    });
+});


### PR DESCRIPTION
Completed `Event` methods for registration and checkin. User isn't allowed to register twice, while duplicate checkins aren't checked.
Now, before linking a steamid64 to a users discord id, it's first checked for existence in the rocketleague.lv database. If it doesn't exist, user is asked to ask an admin to be added before being able to link.
Now, when the *unlink* command is used, the player record is kept, only the `steamid64` field is cleared.

Should event be checked if it's visible, before allowing user to register or check in?
Should registration or checkin times be added?
Should max MMR be rechecked upon checkin? (It's updated upon registration, kinda makes it redundant to keep it in the `players` collection now though)
Should existence in rocketleague.lv database be checked upon registration/checkin?